### PR TITLE
ci: validate Caddy configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,24 @@
 on:
   push:
+  pull_request:
 
 jobs:
+  validate_config:
+    runs-on: ubuntu-latest
+    env:
+      PROXY_PORT: 8080
+      PROXY_USERNAME: ci-user
+      PROXY_PASSWORD: ci-password
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+      - name: Validate Caddyfile formatting
+        run: ./caddy fmt --diff ./Caddyfile
+      - name: Validate Caddyfile config
+        run: ./caddy validate --config ./Caddyfile
+
   deploy_dev:
+    needs: validate_config
     if: github.ref == 'refs/heads/develop'
     uses: 18F/analytics-egress-proxy/.github/workflows/deploy.yml@develop
     with:
@@ -19,6 +35,7 @@ jobs:
       PROXY_USERNAME: ${{ secrets.PROXY_USERNAME_DEV }}
       PROXY_PASSWORD: ${{ secrets.PROXY_PASSWORD_DEV }}
   deploy_stg:
+    needs: validate_config
     if: github.ref == 'refs/heads/staging'
     uses: 18F/analytics-egress-proxy/.github/workflows/deploy.yml@develop
     with:
@@ -35,6 +52,7 @@ jobs:
       PROXY_USERNAME: ${{ secrets.PROXY_USERNAME_STG }}
       PROXY_PASSWORD: ${{ secrets.PROXY_PASSWORD_STG }}
   deploy_prd:
+    needs: validate_config
     if: github.ref == 'refs/heads/master'
     uses: 18F/analytics-egress-proxy/.github/workflows/deploy.yml@develop
     with:

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,41 +1,41 @@
 {
-  debug
-  log {
-    format json
-    level debug
-  }
-  admin off
-  auto_https off
+	debug
+	log {
+		format json
+		level debug
+	}
+	admin off
+	auto_https off
 }
 
 :{$PROXY_PORT} {
-  route {
-    # Act as a forward proxy for incoming requests
-    forward_proxy {
-      # Require a username/password on requests to this server to attempt to
-      # prevent non-application requests to this server. (Provided at deploy
-      # time to both this server and the application instances.)
-      basic_auth {$PROXY_USERNAME} {$PROXY_PASSWORD}
+	route {
+		# Act as a forward proxy for incoming requests
+		forward_proxy {
+			# Require a username/password on requests to this server to attempt to
+			# prevent non-application requests to this server. (Provided at deploy
+			# time to both this server and the application instances.)
+			basic_auth {$PROXY_USERNAME} {$PROXY_PASSWORD}
 
-      # Only allow outgoing requests to be made to an IP/domain using port 443
-      ports 443
+			# Only allow outgoing requests to be made to an IP/domain using port 443
+			ports 443
 
-      # Don't send the request originator's IP as a "Forwarded for" header to
-      # prevent application IPs from leaking to network traffic listeners.
-      hide_ip
+			# Don't send the request originator's IP as a "Forwarded for" header to
+			# prevent application IPs from leaking to network traffic listeners.
+			hide_ip
 
-      acl {
-        # Only allow requests to domains that the analytics.usa.gov application
-        # components need to access on the public internet. Deny requests to
-        # all other domains
-        allow *.amazonaws.com *.googleapis.com *.newrelic.com
-        deny all
-      }
-    }
-  }
-  log {
-    format json
-    level debug
-    output stdout
-  }
+			acl {
+				# Only allow requests to domains that the analytics.usa.gov application
+				# components need to access on the public internet. Deny requests to
+				# all other domains
+				allow *.amazonaws.com *.googleapis.com *.newrelic.com
+				deny all
+			}
+		}
+	}
+	log {
+		format json
+		level debug
+		output stdout
+	}
 }


### PR DESCRIPTION
## Summary
- add a CI validation job for Caddyfile formatting and config parsing
- gate deploy jobs on that validation job
- format the Caddyfile with the bundled Caddy binary

## Testing
- `./caddy fmt --diff ./Caddyfile`
- `PROXY_PORT=8080 PROXY_USERNAME=ci-user PROXY_PASSWORD=ci-password ./caddy validate --config ./Caddyfile`